### PR TITLE
fix: include more tool paths in the cache slug for pre-commit action runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.3'
     - name: self test action
       uses: ./

--- a/action.yml
+++ b/action.yml
@@ -12,9 +12,21 @@ runs:
     shell: bash
   - run: python -m pip freeze --local
     shell: bash
+  - run: |
+      tf=$(mktemp)
+      echo "arch=$(uname -p)" >> "$tf"
+      for program in python ruby go cargo ; do
+        if command -v $program >/dev/null 2>&1 ; then
+          echo "$program=$(which $program)" >> "$tf"
+        fi
+      done
+      hash="$(sha256sum < "$tf" | awk '{print $1}')"
+      echo "dependencyHash=${hash}" >> $GITHUB_OUTPUT
+    shell: bash
+    id: computeDependencies
   - uses: actions/cache@v4
     with:
       path: ~/.cache/pre-commit
-      key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      key: pre-commit-3|${{ steps.computeDependencies.outputs.dependencyHash }}|${{ hashFiles('.pre-commit-config.yaml') }}
   - run: pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
     shell: bash


### PR DESCRIPTION
Upstream only includes the python path, but people might have other tools installed that get included in the cache. I picked a few arbitrarily to hash; we can add more as time goes on.

Tested with `act` and confirmed it works.

Upstream does not want to accept any changes to this repo, but also hasn't maintained it in forever, so we'll just keep this in a fork.