### PR TITLE
chore: redo how github actions are used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 on:
-  pull_request:
-  push:
-    branches: [main, test-me-*]
-
+  workflow_call:
 jobs:
   main:
     runs-on: ubuntu-latest

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -1,0 +1,7 @@
+on:
+  pull_request:
+    branches: ['*']
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit

--- a/.github/workflows/on-push-tag.yml
+++ b/.github/workflows/on-push-tag.yml
@@ -10,6 +10,6 @@ jobs:
     uses: ./.github/workflows/ci.yml
     secrets: inherit
   release:
-    uses: ./github/workflows/release.yml
+    uses: ./.github/workflows/release.yml
     needs: [ci]
     secrets: inherit

--- a/.github/workflows/on-push-tag.yml
+++ b/.github/workflows/on-push-tag.yml
@@ -1,0 +1,15 @@
+on:
+  push:
+    tags:
+      - 'v*'
+permissions:
+  contents: write
+  packages: write
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
+  release:
+    uses: ./github/workflows/release.yml
+    needs: [ci]
+    secrets: inherit

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -1,0 +1,7 @@
+on:
+  push:
+    branches: ['main']
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Publish Release
+on:
+  workflow_call:
+concurrency:
+  group: ${{ github.workflow }}
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Create a Release
+      uses: softprops/action-gh-release@v2
+      with:
+        body: "Create release ${{ github.ref_name }}"
+        make_latest: true
+    - shell: bash
+      run: |
+        tag="${{ github.ref_name }}"
+        if [[ "$tag" =~ ^v[0-9]+\. ]]; then
+          branch_name="$(echo "$tag" | cut -d. -f 1)"
+          git checkout -b "$branch_name" ${{ github.sha }}
+          git push -f origin "$branch_name":"$branch_name"
+        fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,21 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
-    hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
-    -   id: check-yaml
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.6.0
+  hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: check-yaml
+  - id: check-json
+  - id: check-merge-conflict
+- repo: https://github.com/python-jsonschema/check-jsonschema
+  rev: '0.28.5'
+  hooks:
+  - id: check-dependabot
+    args: ["--verbose"]
+  - id: check-github-actions
+    args: ["--verbose"]
+- repo: https://github.com/Mateusz-Grzelinski/actionlint-py
+  rev: v1.7.1.15
+  hooks:
+  - id: actionlint
+    additional_dependencies: [ pyflakes>=3.0.1, shellcheck-py>=0.9.0.5 ]


### PR DESCRIPTION
This changes the actions for this repository:

 1. Switches them to reusable actions so we can have dependencies
 2. Adds a new action to run on tag push that auto-creates a release and manages the semver branch
